### PR TITLE
feat: live X/Twitter testimonials on homepage

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -23,6 +23,7 @@
     <!-- Performance Optimization -->
     <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
     <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+    <link rel="dns-prefetch" href="https://platform.twitter.com" />
     <meta http-equiv="x-dns-prefetch-control" content="on" />
     <meta
       name="keywords"

--- a/client/src/components/HomeComponents/Testimonial.jsx
+++ b/client/src/components/HomeComponents/Testimonial.jsx
@@ -1,152 +1,173 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
+import { format } from "date-fns";
+import { BsPatchCheckFill } from "react-icons/bs";
+import testimonialTweets from "../../config/testimonialTweets";
+import { useTweet } from "../../hooks/useTweet";
 
-// Separate testimonial data with real avatar URLs
-const testimonials = [
-  {
-    id: 1,
-    name: "Bhavesh Singh",
-    handle: "@BhaveshSingh__",
-    image:
-      "https://media.licdn.com/dms/image/D5603AQEBO8CqMpa_CA/profile-displayphoto-shrink_200_200/0/1707073254865?e=2147483647&v=beta&t=LpXcGOheCaNAKyu3ntIr4j-ogKsRVIgReb68FhnOR6U",
-    content:
-      "Webmark has completely transformed how I organize my dev resources. The ability to categorize and tag bookmarks makes finding documentation and tutorials so much faster. The search functionality is incredibly powerful!",
-    date: "Nov 22, 2024",
-    rotation: -1,
-  },
-  {
-    id: 2,
-    name: "Shreyansh",
-    handle: "@shreyansh121",
-    image:
-      "https://media.licdn.com/dms/image/v2/D4E03AQGrCjkMfhLyrg/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1686543439342?e=2147483647&v=beta&t=wFw57Ki7LeA8XC2fZvMsfNizRHXtKdK1p7gcPJMLEP0",
-    content:
-      "As a full-stack developer, I juggle countless resources daily. Webmark's collections feature helps me keep everything organized by project, and the dark mode is perfect for late-night coding sessions.",
-    date: "Dec 4, 2024",
-    rotation: 1,
-  },
-  {
-    id: 3,
-    name: "Vansh",
-    handle: "@gilhotravansh7",
-    image:
-      "https://media.licdn.com/dms/image/v2/D5603AQE8An1ZkqVLdg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1718966097347?e=1738195200&v=beta&t=qz4Qy22xWisj4eEL3EukBn_Lqe9jKra-cVVtQMOk16U",
-    content:
-      "The custom tagging system in Webmark is a game-changer for UX research. I can easily sort and find inspiration from different sources. The quick search feature saves me hours every week!",
-    date: "Nov 17, 2024",
-    rotation: -1,
-  },
-  {
-    id: 4,
-    name: "Chahat Kesharwani",
-    handle: "@chahatkesh",
-    image:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQlfTZ5us199K6vayRfGfrtHydVyfNE0o0p9w&s",
-    content:
-      "Love how Webmark syncs across all my devices. The smart collections and drag-and-drop interface make organizing bookmarks actually enjoyable. It's become an essential part of my daily workflow.",
-    date: "Oct 28, 2024",
-    rotation: 1,
-  },
-  {
-    id: 5,
-    name: "Harsh",
-    handle: "@Harshva42964351",
-    image:
-      "https://pbs.twimg.com/profile_images/1719700935306252288/RrIeBRSy_400x400.jpg",
-    content:
-      "The Chrome extension is fantastic! One-click saving with automatic tag suggestions has made my research workflow so much more efficient. Webmark is my digital library organizer!",
-    date: "Nov 5, 2024",
-    rotation: -1,
-  },
-  {
-    id: 6,
-    name: "Anay Kesharwani",
-    handle: "@A_anay_",
-    image:
-      "https://pbs.twimg.com/profile_images/1519930124434505729/zIrIx_En_400x400.jpg",
-    content:
-      "Finally found the perfect bookmark manager! The ability to add notes to bookmarks helps me remember why I saved something. The search feature is lightning fast!",
-    date: "Nov 13, 2024",
-    rotation: 1,
-  },
-];
+const getTweetId = (url) => {
+  const match = url.match(/(?:twitter\.com|x\.com)\/\w+\/status\/(\d+)/);
+  return match?.[1] ?? null;
+};
 
-const Testimonial = () => {
+const getColumnCount = () => {
+  if (typeof window === "undefined") return 1;
+  if (window.matchMedia("(min-width: 1024px)").matches) return 3;
+  if (window.matchMedia("(min-width: 640px)").matches) return 2;
+  return 1;
+};
+
+const buildBentoColumns = (tweets, columnCount) => {
+  const columns = Array.from({ length: columnCount }, () => []);
+
+  tweets.forEach((tweet, index) => {
+    columns[index % columnCount].push({ tweet, index });
+  });
+
+  return columns;
+};
+
+const useBentoColumnCount = () => {
+  const [columnCount, setColumnCount] = useState(getColumnCount);
+
   useEffect(() => {
-    const initializeScroller = () => {
-      const scrollers = document.querySelectorAll(".scroller");
+    const updateColumnCount = () => setColumnCount(getColumnCount());
+    updateColumnCount();
 
-      if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-        addAnimation(scrollers);
-      }
-    };
-
-    const addAnimation = (scrollers) => {
-      scrollers.forEach((scroller) => {
-        scroller.setAttribute("data-animated", true);
-        const scrollerInner = scroller.querySelector(".scroller-inner");
-        const scrollerContent = Array.from(scrollerInner.children);
-
-        scrollerContent.forEach((item) => {
-          const duplicatedItem = item.cloneNode(true);
-          duplicatedItem.setAttribute("aria-hidden", true);
-          scrollerInner.appendChild(duplicatedItem);
-        });
-      });
-    };
-
-    initializeScroller();
+    window.addEventListener("resize", updateColumnCount);
+    return () => window.removeEventListener("resize", updateColumnCount);
   }, []);
 
-  const TestimonialCard = ({ testimonial }) => (
-    <article
-      className="ml-3 mr-3 shadow p-5 bg-[#ffffffb3] rounded-2xl flex flex-col w-[22rem] relative hover:shadow-lg transition-shadow duration-300"
-      style={{ transform: `rotate(${testimonial.rotation}deg)` }}>
-      <header className="flex items-center mb-4 gap-3">
-        <img
-          className="rounded-full flex-shrink-0 max-w-full h-auto object-cover"
-          width={44}
-          height={44}
-          src={testimonial.image}
-          alt={`${testimonial.name}'s profile picture`}
-          loading="lazy"
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src =
-              "https://ui-avatars.com/api/?name=" +
-              encodeURIComponent(testimonial.name);
-          }}
-        />
-        <div>
-          <div className="font-[700]">{testimonial.name}</div>
-          <div>
-            <a
-              className="text-[#6b7280cc] text-[0.875rem] leading-[1.5715em] font-[500] hover:text-blue-600 transition-colors duration-300"
-              href="#"
-              rel="noopener noreferrer">
-              {testimonial.handle}
-            </a>
-          </div>
+  return columnCount;
+};
+
+const formatTweetDate = (createdAt) => {
+  if (!createdAt) return "";
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return "";
+  return format(date, "MMM d, yyyy");
+};
+
+const XIcon = () => (
+  <svg
+    className="fill-current text-gray-400"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="14"
+    viewBox="0 0 17 15"
+    aria-hidden="true">
+    <path
+      fillRule="evenodd"
+      d="M16.928 14.054H11.99L8.125 9.162l-4.427 4.892H1.243L6.98 7.712.928.054H5.99L9.487 4.53 13.53.054h2.454l-5.358 5.932 6.303 8.068Zm-4.26-1.421h1.36L5.251 1.4H3.793l8.875 11.232Z"
+    />
+  </svg>
+);
+
+const VerifiedBadge = () => (
+  <BsPatchCheckFill
+    aria-label="Verified account"
+    className="h-[1.05rem] w-[1.05rem] flex-shrink-0 text-[#1D9BF0]"
+  />
+);
+
+const TweetCardSkeleton = ({ className = "" }) => (
+  <article className={`tweet-card ${className}`.trim()}>
+    <div className="tweet-card-surface animate-pulse">
+      <div className="flex items-center gap-3 mb-5">
+        <div className="h-11 w-11 rounded-full bg-gray-200/80" />
+        <div className="space-y-2">
+          <div className="h-3.5 w-28 rounded-full bg-gray-200/80" />
+          <div className="h-3 w-20 rounded-full bg-gray-200/60" />
         </div>
-      </header>
-      <div className="text-[#374151] text-[0.875rem] leading-[1.5715em] flex-grow">
-        {testimonial.content}
       </div>
-      <footer className="text-[#374151] gap-2.5 flex items-center mt-4">
-        <svg
-          className="fill-current"
-          xmlns="http://www.w3.org/2000/svg"
-          width="17"
-          height="15"
-          fill="none">
-          <path
-            fillRule="evenodd"
-            d="M16.928 14.054H11.99L8.125 9.162l-4.427 4.892H1.243L6.98 7.712.928.054H5.99L9.487 4.53 13.53.054h2.454l-5.358 5.932 6.303 8.068Zm-4.26-1.421h1.36L5.251 1.4H3.793l8.875 11.232Z"
+      <div className="space-y-2.5">
+        <div className="h-3 w-full rounded-full bg-gray-200/70" />
+        <div className="h-3 w-[92%] rounded-full bg-gray-200/60" />
+        <div className="h-3 w-[75%] rounded-full bg-gray-200/50" />
+      </div>
+    </div>
+  </article>
+);
+
+const TweetCard = ({ tweetUrl, className = "" }) => {
+  const tweetId = getTweetId(tweetUrl);
+  const { data: tweet, isLoading, error } = useTweet(tweetId);
+
+  if (isLoading) return <TweetCardSkeleton className={className} />;
+
+  if (error || !tweet) {
+    return (
+      <article className={`tweet-card ${className}`.trim()}>
+        <div className="tweet-card-surface text-sm text-gray-500">
+          Unable to load tweet.
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className={`tweet-card ${className}`.trim()}>
+      <a
+        href={tweet.url || tweetUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="tweet-card-surface group">
+        <header className="flex items-center gap-3 mb-5">
+          <img
+            className="h-11 w-11 rounded-full object-cover ring-1 ring-black/5"
+            src={tweet.user.avatar}
+            alt={`${tweet.user.name}'s profile`}
+            loading="lazy"
+            onError={(e) => {
+              e.target.onerror = null;
+              e.target.src = `https://ui-avatars.com/api/?name=${encodeURIComponent(tweet.user.name)}&background=f3f4f6&color=374151`;
+            }}
           />
-        </svg>
-        <div className="text-[0.75rem] leading-[1.5]">{testimonial.date}</div>
-      </footer>
+          <div className="min-w-0">
+            <div className="flex items-center gap-1">
+              <span className="truncate font-semibold text-gray-900">
+                {tweet.user.name}
+              </span>
+              {tweet.user.verified && <VerifiedBadge />}
+            </div>
+            <span className="block truncate text-sm text-gray-500 group-hover:text-gray-700 transition-colors">
+              {tweet.user.handle}
+            </span>
+          </div>
+        </header>
+
+        <p className="text-[0.9375rem] leading-relaxed text-gray-700 whitespace-pre-wrap">
+          {tweet.text}
+        </p>
+
+        {tweet.mediaUrl && (
+          <img
+            className="mt-4 w-full rounded-xl object-cover ring-1 ring-black/5"
+            src={tweet.mediaUrl}
+            alt=""
+            loading="lazy"
+          />
+        )}
+
+        <footer className="mt-5 flex items-center gap-2 text-xs text-gray-400">
+          <XIcon />
+          <span>{formatTweetDate(tweet.createdAt)}</span>
+        </footer>
+      </a>
     </article>
   );
+};
+
+const Testimonial = () => {
+  const columnCount = useBentoColumnCount();
+
+  if (testimonialTweets.length === 0) {
+    return null;
+  }
+
+  const columns =
+    columnCount === 1
+      ? [testimonialTweets.map((tweet, index) => ({ tweet, index }))]
+      : buildBentoColumns(testimonialTweets, columnCount);
 
   return (
     <section className="relative py-12 md:py-20">
@@ -156,24 +177,28 @@ const Testimonial = () => {
             Trusted and loved by Professionals
           </h2>
         </div>
-      </div>
-      <div className="flex relative w-[100vw] justify-center ml-auto mr-auto">
-        {/* Background effects */}
-        <div className="translate-x-[-9rem] absolute bottom-[5rem] -z-10">
-          <div className="blur-[160px] opacity-35 to-[#111827] from-[#3b82f6] bg-gradient-to-tr h-80 w-80 rounded-full" />
-        </div>
-        <div className="absolute bottom-[-2.5rem] -z-10">
-          <div className="blur-[160px] opacity-40 to-[#111827] from-[#3b82f6] bg-gradient-to-tr h-80 w-80 rounded-full" />
-        </div>
-        <div className="absolute bottom-0 -z-10">
-          <div className="blur-[20px] h-56 w-56 rounded-full border-[20px] border-white" />
-        </div>
 
-        {/* Testimonial scroller */}
-        <div className="scroller w-[90vw] pt-12 pb-12 md:pt-20 md:pb-20 flex">
-          <div className="scroller-inner flex">
-            {testimonials.map((testimonial) => (
-              <TestimonialCard key={testimonial.id} testimonial={testimonial} />
+        <div className="relative mt-10 md:mt-14">
+          <div className="translate-x-[-9rem] absolute top-[4rem] -z-10">
+            <div className="blur-[160px] opacity-35 to-[#111827] from-[#3b82f6] bg-gradient-to-tr h-80 w-80 rounded-full" />
+          </div>
+          <div className="absolute top-[10rem] right-0 -z-10">
+            <div className="blur-[160px] opacity-40 to-[#111827] from-[#3b82f6] bg-gradient-to-tr h-80 w-80 rounded-full" />
+          </div>
+
+          <div className="testimonial-bento">
+            {columns.map((column, columnIndex) => (
+              <div
+                key={`column-${columnIndex}`}
+                className="testimonial-bento-column">
+                {column.map(({ tweet, index }) => (
+                  <TweetCard
+                    key={`${tweet.url}-${index}`}
+                    tweetUrl={tweet.url}
+                    className="testimonial-bento-item"
+                  />
+                ))}
+              </div>
             ))}
           </div>
         </div>

--- a/client/src/config/testimonialTweets.js
+++ b/client/src/config/testimonialTweets.js
@@ -1,0 +1,11 @@
+// Add real tweet URLs here — supports both x.com and twitter.com links.
+const testimonialTweets = [
+  {
+    url: "https://x.com/chahatkesh/status/1931481330606584136",
+  },
+  {
+    url: "https://x.com/chahatkesh/status/1905560061419946341",
+  }
+];
+
+export default testimonialTweets;

--- a/client/src/hooks/useTweet.js
+++ b/client/src/hooks/useTweet.js
@@ -1,0 +1,12 @@
+import useSWR from 'swr';
+import { apiRequest } from '../utils/apiClient';
+
+export const useTweet = (tweetId) =>
+  useSWR(
+    tweetId ? `/api/tweets/${tweetId}` : null,
+    (path) => apiRequest(path).then((response) => response.data),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+    }
+  );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -257,37 +257,68 @@ ul {
   }
 }
 
-/* Scroller */
-.scroller[data-animated="true"] {
-  overflow: hidden;
-  -webkit-mask: linear-gradient(
-    90deg,
-    transparent,
-    white 20%,
-    white 80%,
-    transparent
-  );
-  mask: linear-gradient(90deg, transparent, white 20%, white 80%, transparent);
+/* Testimonial bento masonry */
+.testimonial-bento {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  max-width: 72rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.scroller[data-animated="true"] .scroller-inner {
-  width: max-content;
-  flex-wrap: nowrap;
-  animation: scroll 50s linear infinite;
+.testimonial-bento-column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-@keyframes scroll {
-  to {
-    transform: translate(-50%);
+.testimonial-bento-item {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .testimonial-bento {
+    gap: 1.5rem;
+  }
+
+  .testimonial-bento-column {
+    gap: 2rem;
   }
 }
-.scroller:hover {
-  .scroller-inner {
-    animation-play-state: paused;
+
+@media (min-width: 1024px) {
+  .testimonial-bento-column {
+    gap: 2.5rem;
   }
-  article {
-    transform: rotate(0);
-  }
+}
+
+.tweet-card {
+  width: 100%;
+}
+
+.tweet-card-surface {
+  display: block;
+  height: 100%;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease,
+    border-color 0.25s ease,
+    background-color 0.25s ease;
+}
+
+.tweet-card-surface:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
 }
 @layer base {
   * {

--- a/server/controllers/tweetController.js
+++ b/server/controllers/tweetController.js
@@ -1,0 +1,26 @@
+import { fetchTweetById } from '../utils/tweetFetcher.js';
+
+const tweetCache = new Map();
+const TWEET_CACHE_TTL_MS = 60 * 60 * 1000;
+
+export const getTweet = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const cached = tweetCache.get(id);
+
+    if (cached && Date.now() - cached.timestamp < TWEET_CACHE_TTL_MS) {
+      return res.json({ success: true, data: cached.data });
+    }
+
+    const data = await fetchTweetById(id);
+    tweetCache.set(id, { data, timestamp: Date.now() });
+
+    return res.json({ success: true, data });
+  } catch (error) {
+    const status = error.status || 500;
+    return res.status(status).json({
+      success: false,
+      message: error.message || 'Failed to fetch tweet',
+    });
+  }
+};

--- a/server/routes/tweetRoute.js
+++ b/server/routes/tweetRoute.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getTweet } from '../controllers/tweetController.js';
+
+const router = express.Router();
+
+router.get('/:id', getTweet);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ import bookmarkRouter from './routes/bookmarkRoute.js'
 import statsRoute from './routes/statsRoute.js';
 import clickRoute from './routes/clickRoute.js';
 import cronRoute from './routes/cronRoute.js';
+import tweetRoute from './routes/tweetRoute.js';
 import { initializeCronJobs } from './utils/cronJobs.js';
 import passport from './config/passport.js';
 import 'dotenv/config'
@@ -72,6 +73,7 @@ app.use("/api/bookmarks", bookmarkRouter)
 app.use('/api/stats', statsRoute);
 app.use('/api/clicks', clickRoute);
 app.use('/api/cron', cronRoute);
+app.use('/api/tweets', tweetRoute);
 
 app.get('/', (req, res) => {
   res.send("API Working")

--- a/server/utils/tweetFetcher.js
+++ b/server/utils/tweetFetcher.js
@@ -1,0 +1,87 @@
+const SYNDICATION_URL = 'https://cdn.syndication.twimg.com/tweet-result';
+const TWEET_ID_PATTERN = /^[0-9]+$/;
+
+const getSyndicationToken = (id) =>
+  ((Number(id) / 1e15) * Math.PI)
+    .toString(36)
+    .replace(/(0+|\.)/g, '');
+
+const getDisplayText = (tweet) => {
+  const text = tweet.text || '';
+  const range = tweet.display_text_range;
+
+  if (Array.isArray(range) && range.length === 2) {
+    return text.slice(range[0], range[1]).trimEnd();
+  }
+
+  return text;
+};
+
+const getMediaUrl = (tweet) => {
+  const photo = tweet.photos?.[0]?.url;
+  if (photo) return photo;
+
+  const media = tweet.mediaDetails?.[0]?.media_url_https;
+  if (media) return media;
+
+  return null;
+};
+
+const normalizeTweet = (id, tweet) => {
+  const screenName = tweet.user?.screen_name || '';
+  const avatar = tweet.user?.profile_image_url_https?.replace(
+    '_normal',
+    '_400x400'
+  );
+
+  return {
+    id,
+    text: getDisplayText(tweet),
+    createdAt: tweet.created_at || null,
+    url: screenName ? `https://x.com/${screenName}/status/${id}` : null,
+    user: {
+      name: tweet.user?.name || 'Unknown',
+      handle: screenName ? `@${screenName}` : '',
+      avatar: avatar || null,
+      verified: Boolean(tweet.user?.verified || tweet.user?.is_blue_verified),
+    },
+    mediaUrl: getMediaUrl(tweet),
+  };
+};
+
+export const fetchTweetById = async (id) => {
+  if (!id || id.length > 40 || !TWEET_ID_PATTERN.test(id)) {
+    const error = new Error('Invalid tweet id');
+    error.status = 400;
+    throw error;
+  }
+
+  const url = new URL(SYNDICATION_URL);
+  url.searchParams.set('id', id);
+  url.searchParams.set('lang', 'en');
+  url.searchParams.set('token', getSyndicationToken(id));
+
+  const response = await fetch(url.toString());
+
+  if (response.status === 404) {
+    const error = new Error('Tweet not found');
+    error.status = 404;
+    throw error;
+  }
+
+  if (!response.ok) {
+    const error = new Error('Failed to fetch tweet');
+    error.status = response.status;
+    throw error;
+  }
+
+  const data = await response.json();
+
+  if (data?.__typename === 'TweetTombstone') {
+    const error = new Error('Tweet unavailable');
+    error.status = 410;
+    throw error;
+  }
+
+  return normalizeTweet(id, data);
+};


### PR DESCRIPTION
## Summary
- Replace hardcoded testimonial cards with live tweets fetched from X/Twitter via a server-side syndication proxy (`/api/tweets/:id`) with 1-hour in-memory caching
- Redesign the testimonials section as a responsive bento masonry layout with skeleton loading, verified badges, and media support
- Add configurable tweet URLs in `client/src/config/testimonialTweets.js` and a `useTweet` SWR hook for client-side fetching

## Test plan
- [x] Start dev server and confirm homepage testimonials load real tweet content
- [x] Verify skeleton states appear briefly while tweets fetch
- [x] Test responsive layout at mobile, tablet, and desktop breakpoints
- [x] Confirm tweet cards link out to the correct X/Twitter status URLs
- [x] Test error state by temporarily using an invalid tweet ID
- [x] Verify `/api/tweets/:id` returns cached responses on repeat requests